### PR TITLE
Fix Access-Control-Allow-Origin issue

### DIFF
--- a/webview/src/java/com/defold/webview/WebViewJNI.java
+++ b/webview/src/java/com/defold/webview/WebViewJNI.java
@@ -279,6 +279,7 @@ public class WebViewJNI {
 
         WebSettings webSettings = info.webview.getSettings();
         webSettings.setJavaScriptEnabled(true);
+        webSettings.setAllowFileAccessFromFileURLs(true);
 
         info.webview.addJavascriptInterface(info.webviewClient, JS_NAMESPACE);
 


### PR DESCRIPTION
This option helps to avoid access control errors if HTML or js tries to load png files, fonts and so on from `files:///...`
https://developer.android.com/reference/android/webkit/WebSettings.html#setAllowFileAccessFromFileURLs(boolean)