### PR TITLE
add support for macOS

### DIFF
--- a/webview/ext.manifest
+++ b/webview/ext.manifest
@@ -1,6 +1,10 @@
 name: WebViewExternal
 
 platforms:
+  x86_64-osx:
+    context:
+        frameworks: ["WebKit"]
+
   arm64-ios:
     context:
         frameworks: ["WebKit"]

--- a/webview/src/webview_common.cpp
+++ b/webview/src/webview_common.cpp
@@ -1,4 +1,4 @@
-#if defined(DM_PLATFORM_ANDROID) || defined(DM_PLATFORM_IOS)
+#if defined(DM_PLATFORM_ANDROID) || defined(DM_PLATFORM_IOS) || defined (DM_PLATFORM_OSX)
 
 #include <assert.h>
 #include <dmsdk/dlib/log.h>
@@ -104,7 +104,7 @@ static int Create(lua_State* L)
     info.m_Self = dmScript::Ref(L, LUA_REGISTRYINDEX);
     info.m_L = dmScript::GetMainThread(L);
 
-    int webview_id = Platform_Create(L, &info);
+    int webview_id = Platform_Create(L, &info); 
     lua_pushnumber(L, webview_id);
 
     assert(top + 1 == lua_gettop(L));

--- a/webview/src/webview_null.cpp
+++ b/webview/src/webview_null.cpp
@@ -1,4 +1,4 @@
-#if !defined(DM_PLATFORM_ANDROID) && !defined(DM_PLATFORM_IOS)
+#if !defined(DM_PLATFORM_ANDROID) && !defined(DM_PLATFORM_IOS) && !defined(DM_PLATFORM_OSX)
 extern "C" void WebViewExternal()
 {
 


### PR DESCRIPTION
For now, extension-webview only support iOS & Android platform, which may be hard to develop and debug from local machine. So I added support for it to work on macOS with NS* API on macOS and WKWebView ( WebKit ) (as it was on iOS).

changes :

* Renamed `webview_ios.mm` -> `webview_darwin.mm`
* Added parts to support macOS by using NS* components to replace UI* conponents
+ Added OSX platform in `webview_common.cpp` & `webview_common.h`
