### PR TITLE
Fix intermittent crash on extension finalize

### DIFF
--- a/main/main.gui
+++ b/main/main.gui
@@ -8,7 +8,7 @@ background_color {
 nodes {
   position {
     x: 320.0
-    y: 125.0
+    y: 195.0
     z: 0.0
     w: 1.0
   }
@@ -169,7 +169,7 @@ nodes {
 nodes {
   position {
     x: 215.0
-    y: 55.0
+    y: 125.0
     z: 0.0
     w: 1.0
   }
@@ -330,7 +330,7 @@ nodes {
 nodes {
   position {
     x: 425.0
-    y: 55.0
+    y: 125.0
     z: 0.0
     w: 1.0
   }
@@ -491,7 +491,7 @@ nodes {
 nodes {
   position {
     x: 320.0
-    y: 265.0
+    y: 335.0
     z: 0.0
     w: 1.0
   }
@@ -652,7 +652,7 @@ nodes {
 nodes {
   position {
     x: 320.0
-    y: 195.0
+    y: 265.0
     z: 0.0
     w: 1.0
   }
@@ -798,6 +798,328 @@ nodes {
   adjust_mode: ADJUST_MODE_FIT
   line_break: false
   parent: "button_html/larrybutton"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  outline_alpha: 0.0
+  shadow_alpha: 1.0
+  overridden_fields: 3
+  overridden_fields: 8
+  overridden_fields: 31
+  template_node_child: true
+  text_leading: 1.0
+  text_tracking: 0.0
+}
+nodes {
+  position {
+    x: 215.0
+    y: 55.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 0.5
+    y: 0.5
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEMPLATE
+  id: "button_create"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  template: "/dirtylarry/button.gui"
+  template_node_child: false
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 380.0
+    y: 120.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "button/button_normal"
+  id: "button_create/larrybutton"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "button_create"
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 32.0
+    y: 32.0
+    z: 32.0
+    w: 32.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  overridden_fields: 4
+  template_node_child: true
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.5
+    y: 1.5
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "Create"
+  font: "larryfont"
+  id: "button_create/larrylabel"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  outline {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: false
+  parent: "button_create/larrybutton"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  outline_alpha: 0.0
+  shadow_alpha: 1.0
+  overridden_fields: 3
+  overridden_fields: 8
+  overridden_fields: 31
+  template_node_child: true
+  text_leading: 1.0
+  text_tracking: 0.0
+}
+nodes {
+  position {
+    x: 425.0
+    y: 55.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 0.5
+    y: 0.5
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEMPLATE
+  id: "button_destroy"
+  layer: ""
+  inherit_alpha: true
+  alpha: 1.0
+  template: "/dirtylarry/button.gui"
+  template_node_child: false
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 380.0
+    y: 120.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_BOX
+  blend_mode: BLEND_MODE_ALPHA
+  texture: "button/button_normal"
+  id: "button_destroy/larrybutton"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  adjust_mode: ADJUST_MODE_FIT
+  parent: "button_destroy"
+  layer: ""
+  inherit_alpha: true
+  slice9 {
+    x: 32.0
+    y: 32.0
+    z: 32.0
+    w: 32.0
+  }
+  clipping_mode: CLIPPING_MODE_NONE
+  clipping_visible: true
+  clipping_inverted: false
+  alpha: 1.0
+  overridden_fields: 4
+  template_node_child: true
+  size_mode: SIZE_MODE_MANUAL
+}
+nodes {
+  position {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale {
+    x: 1.5
+    y: 1.5
+    z: 1.0
+    w: 1.0
+  }
+  size {
+    x: 200.0
+    y: 100.0
+    z: 0.0
+    w: 1.0
+  }
+  color {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  type: TYPE_TEXT
+  blend_mode: BLEND_MODE_ALPHA
+  text: "Destroy"
+  font: "larryfont"
+  id: "button_destroy/larrylabel"
+  xanchor: XANCHOR_NONE
+  yanchor: YANCHOR_NONE
+  pivot: PIVOT_CENTER
+  outline {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  shadow {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+  adjust_mode: ADJUST_MODE_FIT
+  line_break: false
+  parent: "button_destroy/larrybutton"
   layer: ""
   inherit_alpha: true
   alpha: 1.0

--- a/main/main.gui_script
+++ b/main/main.gui_script
@@ -50,6 +50,17 @@ local function webview_available()
     return true
 end
 
+local function webview_exists(self)
+    if not webview_available() then
+        return false
+    end
+    if not self.webview_id then
+        print("WebView has been destroyed. Create it again before calling this")
+        return false
+    end
+    return true
+end
+
 local function window_callback(self, event, data)
     if event == window.WINDOW_EVENT_RESIZED then
         self.width = data.width
@@ -74,32 +85,50 @@ end
 
 function on_input(self, action_id, action)
     dirtylarry:button("button_open", action_id, action, function()
-        if not webview_available() then return end
+        if not webview_exists(self) then return end
 
         webview.open(self.webview_id, "https://www.google.com")
     end)
 
     dirtylarry:button("button_eval", action_id, action, function()
-        if not webview_available() then return end
+        if not webview_exists(self) then return end
 
         webview.eval(self.webview_id, "1+1")
     end)
 
     dirtylarry:button("button_html", action_id, action, function()
-        if not webview_available() then return end
+        if not webview_exists(self) then return end
 
         webview.open_raw(self.webview_id, HTML)
     end)
     
     dirtylarry:button("button_show", action_id, action, function()
-        if not webview_available() then return end
+        if not webview_exists(self) then return end
 
         webview.set_visible(self.webview_id, 1)
     end)
 
     dirtylarry:button("button_hide", action_id, action, function()
-        if not webview_available() then return end
+        if not webview_exists(self) then return end
 
         webview.set_visible(self.webview_id, 0)
+    end)
+
+    dirtylarry:button("button_create", action_id, action, function()
+        if not webview_available() then return end
+        if self.webview_id then
+            print("WebView already created")
+            return
+        end
+
+        self.webview_id = webview.create(webview_callback)
+        webview.set_position(self.webview_id, 0, 0, -1, 300)
+    end)
+
+    dirtylarry:button("button_destroy", action_id, action, function()
+        if not webview_exists(self) then return end
+
+        webview.destroy(self.webview_id)
+        self.webview_id = nil
     end)
 end

--- a/webview/src/webview_darwin.mm
+++ b/webview/src/webview_darwin.mm
@@ -301,7 +301,20 @@ int Platform_SetPosition(lua_State* L, int webview_id, int x, int y, int width, 
     #elif defined(DM_PLATFORM_OSX)
     CGRect screenRect = [dmGraphics::GetNativeOSXNSView() frame];
     #endif
-    g_WebView.m_WebViews[webview_id].frame = CGRectMake(x, y, width >= 0 ? width : screenRect.size.width, height >= 0 ? height : screenRect.size.height);
+
+    CGFloat frameWidth = width >= 0 ? width : screenRect.size.width;
+    CGFloat frameHeight = height >= 0 ? height : screenRect.size.height;
+    CGRect frame = CGRectMake(
+        screenRect.origin.x + x,
+        #if defined(DM_PLATFORM_OSX)
+        screenRect.origin.y + screenRect.size.height - frameHeight - y,
+        #else
+        screenRect.origin.y + y,
+        #endif
+        frameWidth,
+        frameHeight
+    );
+    g_WebView.m_WebViews[webview_id].frame = frame;
     return 0;
 }
 

--- a/webview/src/webview_darwin.mm
+++ b/webview/src/webview_darwin.mm
@@ -208,6 +208,7 @@ static void DestroyWebView(int webview_id)
     ClearWebViewInfo(&g_WebView.m_Info[webview_id]);
     [g_WebView.m_WebViews[webview_id] removeFromSuperview];
     [g_WebView.m_WebViews[webview_id] release];
+    g_WebView.m_WebViews[webview_id] = NULL;
 }
 
 int Platform_Destroy(lua_State* L, int webview_id)


### PR DESCRIPTION
Sorry for the 2-in-1 PR, but I was lazy to switch branches.

1. I realised that on macOS the Y-axis is inverted compared to iOS, so this PR makes it behave like on mobile
2. I fixed a crash that was happening due to the fact that destroyed web views were being freed again in Finalize()