### PR TITLE
Fix game view losing focus if webview destroyed while clicking

### DIFF
--- a/webview/src/webview_darwin.mm
+++ b/webview/src/webview_darwin.mm
@@ -206,8 +206,15 @@ int Platform_Create(lua_State* L, dmWebView::WebViewInfo* _info)
 static void DestroyWebView(int webview_id)
 {
     ClearWebViewInfo(&g_WebView.m_Info[webview_id]);
-    [g_WebView.m_WebViews[webview_id] removeFromSuperview];
-    [g_WebView.m_WebViews[webview_id] release];
+    WKWebView *view = g_WebView.m_WebViews[webview_id];
+    #if defined(DM_PLATFORM_OSX)
+    NSWindow *window = dmGraphics::GetNativeOSXNSWindow();
+    if ([window firstResponder] == view) {
+        [window makeFirstResponder:dmGraphics::GetNativeOSXNSView()];
+    }
+    #endif
+    [view removeFromSuperview];
+    [view release];
     g_WebView.m_WebViews[webview_id] = NULL;
 }
 


### PR DESCRIPTION
Happens if you're mid-click while the webview is destroyed and requires a second click to give input focus back to the game view