### PR TITLE
Android: Escape JS string before passing it to eval()

### DIFF
--- a/webview/src/java/com/defold/webview/JSONValue.java
+++ b/webview/src/java/com/defold/webview/JSONValue.java
@@ -1,0 +1,81 @@
+/*
+ * $Id: JSONValue.java,v 1.1 2006/04/15 14:37:04 platform Exp $
+ * Created on 2006-4-15
+ */
+
+ /*
+  * Code from the json-simple project, modified to extract only the escape() function. 
+  * https://github.com/fangyidong/json-simple/blob/351aa583745c6de31eed3ccd921c7589f27e2413/src/main/java/org/json/simple/JSONValue.java
+  *
+  * Original code licensed under the terms of Apache License 2.0: 
+  * http://www.apache.org/licenses/LICENSE-2.0
+  */
+package com.defold.webview;
+
+/**
+ * @author FangYidong<fangyidong@yahoo.com.cn>
+ */
+public class JSONValue {
+	/**
+	 * Escape quotes, \, /, \r, \n, \b, \f, \t and other control characters (U+0000 through U+001F).
+	 * @param s
+	 * @return
+	 */
+	public static String escape(String s){
+		if(s==null)
+			return null;
+        StringBuffer sb = new StringBuffer();
+        escape(s, sb);
+        return sb.toString();
+    }
+
+    /**
+     * @param s - Must not be null.
+     * @param sb
+     */
+    static void escape(String s, StringBuffer sb) {
+    	final int len = s.length();
+		for(int i=0;i<len;i++){
+			char ch=s.charAt(i);
+			switch(ch){
+			case '"':
+				sb.append("\\\"");
+				break;
+			case '\\':
+				sb.append("\\\\");
+				break;
+			case '\b':
+				sb.append("\\b");
+				break;
+			case '\f':
+				sb.append("\\f");
+				break;
+			case '\n':
+				sb.append("\\n");
+				break;
+			case '\r':
+				sb.append("\\r");
+				break;
+			case '\t':
+				sb.append("\\t");
+				break;
+			case '/':
+				sb.append("\\/");
+				break;
+			default:
+                //Reference: http://www.unicode.org/versions/Unicode5.1.0/
+				if((ch>='\u0000' && ch<='\u001F') || (ch>='\u007F' && ch<='\u009F') || (ch>='\u2000' && ch<='\u20FF')){
+					String ss=Integer.toHexString(ch);
+					sb.append("\\u");
+					for(int k=0;k<4-ss.length();k++){
+						sb.append('0');
+					}
+					sb.append(ss.toUpperCase());
+				}
+				else{
+					sb.append(ch);
+				}
+			}
+		}//for
+	}
+}

--- a/webview/src/java/com/defold/webview/WebViewJNI.java
+++ b/webview/src/java/com/defold/webview/WebViewJNI.java
@@ -411,7 +411,7 @@ public class WebViewJNI {
             public void run() {
                 WebViewJNI.this.infos[webview_id].webviewClient.reset(request_id);
                 WebViewJNI.this.infos[webview_id].webviewChromeClient.reset(request_id);
-                String javascript = String.format("javascript:%s.returnResultToJava(eval(\"%s\"))", JS_NAMESPACE, code);
+                String javascript = String.format("javascript:%s.returnResultToJava(eval(\"%s\"))", JS_NAMESPACE, JSONValue.escape(code));
                 WebViewJNI.this.infos[webview_id].webview.loadUrl(javascript);
             }
         });


### PR DESCRIPTION
Previously you couldn't eval JS code that contained quotes, for example, since that would close the string quotes of the string literal passed to `eval()`. 

This PR properly escapes the passed JS string according to the JSON spec. This also matches iOS behaviour.