### PR TITLE
Fix view hierarchy on iOS

### DIFF
--- a/webview/ext.manifest
+++ b/webview/ext.manifest
@@ -12,3 +12,7 @@ platforms:
   armv7-ios:
     context:
         frameworks: ["WebKit"]
+
+  x86_64-ios:
+    context:
+        frameworks: ["WebKit"]

--- a/webview/src/webview_darwin.mm
+++ b/webview/src/webview_darwin.mm
@@ -191,7 +191,7 @@ int Platform_Create(lua_State* L, dmWebView::WebViewInfo* _info)
     g_WebView.m_WebViews[webview_id] = view;
     g_WebView.m_WebViewDelegates[webview_id] = navigationDelegate;
 #if defined(DM_PLATFORM_IOS)
-    UIView * topView = [[[[UIApplication sharedApplication] keyWindow] subviews] lastObject];
+    UIView * topView = [[[[UIApplication sharedApplication] keyWindow] rootViewController] view];
 #elif defined(DM_PLATFORM_OSX)
     NSView * topView = [[[NSApplication sharedApplication] keyWindow] contentView];
 #endif


### PR DESCRIPTION
This PR should fix certain web controls not showing up on iOS. (Fixes #29) I'm attaching the web view to the root view controller's view, which is a parent of the EGL view. I checked the iOS-specific glfw code and I think this shouldn't cause any problems.

I also tried to make it build for iOS Simulator, but it didn't work (see #28)


https://user-images.githubusercontent.com/428060/104181451-80fd5880-5417-11eb-8c27-d4ba5a9be0b4.MP4


