### PR TITLE
Added webview header support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ Thumbs.db
 .cproject
 builtins
 docs/_site
+/.editor_settings
+manifest.private.der
+manifest.public.der
+debug.keystore
+debug.keystore.pass.txt

--- a/main/main.gui_script
+++ b/main/main.gui_script
@@ -24,6 +24,7 @@ local function webview_callback(self, webview_id, request_id, type, data)
 
     elseif type == webview.CALLBACK_RESULT_URL_LOADING then
         print("CALLBACK_RESULT_URL_LOADING")
+        pprint(data)
         -- a page is loading
         -- return false to prevent it from loading
         -- return true or nil to continue loading the page
@@ -89,7 +90,8 @@ function on_input(self, action_id, action)
 
         local options = {
             headers = {
-               ["Accept-Origin"] = "*",
+                ["Accept-Origin"] = "*",
+                ["User-Agent"] = "Foobar 1.0",
             }
         }
         webview.open(self.webview_id, "https://www.google.com", options)

--- a/main/main.gui_script
+++ b/main/main.gui_script
@@ -87,7 +87,12 @@ function on_input(self, action_id, action)
     dirtylarry:button("button_open", action_id, action, function()
         if not webview_exists(self) then return end
 
-        webview.open(self.webview_id, "https://www.google.com")
+        local options = {
+            headers = {
+               ["Accept-Origin"] = "*",
+            }
+        }
+        webview.open(self.webview_id, "https://www.google.com", options)
     end)
 
     dirtylarry:button("button_eval", action_id, action, function()

--- a/webview/api/webview.script_api
+++ b/webview/api/webview.script_api
@@ -111,6 +111,9 @@
           - name: hidden
             type: boolean
             desc: If true, the webview will stay hidden (default=false)
+          - name: headers
+            type: table
+            desc: A table of header keys and values
     examples:
       - desc: |-
                  ```lua

--- a/webview/src/java/com/defold/webview/WebViewJNI.java
+++ b/webview/src/java/com/defold/webview/WebViewJNI.java
@@ -20,12 +20,20 @@ import android.view.WindowInsetsController;
 import android.widget.LinearLayout;
 import android.webkit.ConsoleMessage;
 import android.webkit.JavascriptInterface;
+import android.webkit.MimeTypeMap;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.webkit.WebSettings;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 
 import android.util.Log;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 
 public class WebViewJNI {
@@ -52,6 +60,7 @@ public class WebViewJNI {
         private String continueLoadingUrl;
         private WebViewJNI webviewJNI;
         private String PACKAGE_NAME;
+        private Map<String, String> extraHeaders = new HashMap<>();
 
         // This is a hack to counter for the case where the load() experiences an error
         // In that case, the onReceivedError will be called, and onPageFinished will be called TWICE
@@ -65,6 +74,15 @@ public class WebViewJNI {
             this.webviewID = webview_id;
             PACKAGE_NAME = activity.getApplicationContext().getPackageName();
             reset(-1);
+        }
+
+        public void addHeader(final String header, final String value) {
+            if (value == null) {
+                extraHeaders.remove(header);
+            }
+            else {
+                extraHeaders.put(header, value);
+            }
         }
 
         private String trimTrailingSlash(String url) {
@@ -93,6 +111,36 @@ public class WebViewJNI {
         private boolean shouldContinueLoadingUrl(String url) {
             if (continueLoadingUrl == null) return false;
             return trimTrailingSlash(continueLoadingUrl).equals(trimTrailingSlash(url));
+        }
+
+        @Override
+        public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+            final String method = request.getMethod();
+            final String url = request.getUrl().toString();
+            String ext = MimeTypeMap.getFileExtensionFromUrl(url);
+            String mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext);
+
+            try {
+                HttpURLConnection conn = (HttpURLConnection)new URL(url).openConnection();
+                conn.setRequestMethod(method);
+                for (String header : extraHeaders.keySet()) {
+                    String value = extraHeaders.get(header);
+                    conn.setRequestProperty(header, value);
+                }
+                conn.setDoInput(true);
+                conn.setUseCaches(false);
+
+                return new WebResourceResponse(
+                    mime,
+                    conn.getContentEncoding(),
+                    conn.getInputStream()
+                );
+
+            }
+            catch (Exception e) {
+                Log.e(TAG, "shouldInterceptRequest: " + e);
+            }
+            return null;
         }
 
         @Override
@@ -342,6 +390,10 @@ public class WebViewJNI {
                 }
             }
         });
+    }
+
+    public void addHeader(final int webview_id, final String header, final String value) {
+        WebViewJNI.this.infos[webview_id].webviewClient.addHeader(header, value);
     }
 
     public void loadRaw(final String html, final int webview_id, final int request_id, final int hidden) {

--- a/webview/src/java/com/defold/webview/WebViewJNI.java
+++ b/webview/src/java/com/defold/webview/WebViewJNI.java
@@ -85,6 +85,10 @@ public class WebViewJNI {
             }
         }
 
+        public void clearHeaders() {
+            extraHeaders.clear();
+        }
+
         private String trimTrailingSlash(String url) {
             if (url.endsWith("/")) {
                 url = url.substring(0, url.length() - 1);
@@ -394,6 +398,10 @@ public class WebViewJNI {
 
     public void addHeader(final int webview_id, final String header, final String value) {
         WebViewJNI.this.infos[webview_id].webviewClient.addHeader(header, value);
+    }
+
+    public void clearHeaders(final int webview_id) {
+        WebViewJNI.this.infos[webview_id].webviewClient.clearHeaders();
     }
 
     public void loadRaw(final String html, final int webview_id, final int request_id, final int hidden) {

--- a/webview/src/webview_android.cpp
+++ b/webview/src/webview_android.cpp
@@ -68,6 +68,7 @@ struct WebViewExtensionState
     jmethodID               m_IsVisible;
     jmethodID               m_SetPosition;
     jmethodID               m_AddHeader;
+    jmethodID               m_ClearHeaders;
     dmMutex::HMutex         m_Mutex;
     dmArray<WebViewCommand> m_CmdQueue;
 };
@@ -206,6 +207,15 @@ int Platform_SetPosition(lua_State* L, int webview_id, int x, int y, int width, 
     dmAndroid::ThreadAttacher threadAttacher;
     JNIEnv* env = threadAttacher.GetEnv();
     env->CallVoidMethod(g_WebView.m_WebViewJNI, g_WebView.m_SetPosition, webview_id, x, y, width, height);
+    return 0;
+}
+
+int Platform_ClearHeaders(lua_State* L, int webview_id)
+{
+    CHECK_WEBVIEW_AND_RETURN();
+    dmAndroid::ThreadAttacher threadAttacher;
+    JNIEnv* env = threadAttacher.GetEnv();
+    env->CallVoidMethod(g_WebView.m_WebViewJNI, g_WebView.m_ClearHeaders, webview_id);
     return 0;
 }
 
@@ -406,6 +416,7 @@ dmExtension::Result Platform_AppInitialize(dmExtension::AppParams* params)
     g_WebView.m_IsVisible = env->GetMethodID(webview_class, "isVisible", "(I)I");
     g_WebView.m_SetPosition = env->GetMethodID(webview_class, "setPosition", "(IIIII)V");
     g_WebView.m_AddHeader = env->GetMethodID(webview_class, "addHeader", "(ILjava/lang/String;Ljava/lang/String;)V");
+    g_WebView.m_ClearHeaders = env->GetMethodID(webview_class, "clearHeaders", "(I)V");
 
     int32_t immersiveMode = dmConfigFile::GetInt(params->m_ConfigFile, "android.immersive_mode", 0);
     int32_t displayCutout = dmConfigFile::GetInt(params->m_ConfigFile, "android.display_cutout", 1);

--- a/webview/src/webview_android.cpp
+++ b/webview/src/webview_android.cpp
@@ -67,6 +67,7 @@ struct WebViewExtensionState
     jmethodID               m_SetVisible;
     jmethodID               m_IsVisible;
     jmethodID               m_SetPosition;
+    jmethodID               m_AddHeader;
     dmMutex::HMutex         m_Mutex;
     dmArray<WebViewCommand> m_CmdQueue;
 };
@@ -177,6 +178,7 @@ int Platform_Eval(lua_State* L, int webview_id, const char* code)
     JNIEnv* env = threadAttacher.GetEnv();
     jstring jcode = env->NewStringUTF(code);
     env->CallVoidMethod(g_WebView.m_WebViewJNI, g_WebView.m_Eval, jcode, webview_id, request_id);
+    env->DeleteLocalRef(jcode);
     return request_id;
 }
 
@@ -204,6 +206,19 @@ int Platform_SetPosition(lua_State* L, int webview_id, int x, int y, int width, 
     dmAndroid::ThreadAttacher threadAttacher;
     JNIEnv* env = threadAttacher.GetEnv();
     env->CallVoidMethod(g_WebView.m_WebViewJNI, g_WebView.m_SetPosition, webview_id, x, y, width, height);
+    return 0;
+}
+
+int Platform_AddHeader(lua_State* L, int webview_id, const char* header, const char* value)
+{
+    CHECK_WEBVIEW_AND_RETURN();
+    dmAndroid::ThreadAttacher threadAttacher;
+    JNIEnv* env = threadAttacher.GetEnv();
+    jstring jheader = env->NewStringUTF(header);
+    jstring jvalue = env->NewStringUTF(value);
+    env->CallVoidMethod(g_WebView.m_WebViewJNI, g_WebView.m_AddHeader, webview_id, jheader, jvalue);
+    env->DeleteLocalRef(jheader);
+    env->DeleteLocalRef(jvalue);
     return 0;
 }
 
@@ -390,6 +405,7 @@ dmExtension::Result Platform_AppInitialize(dmExtension::AppParams* params)
     g_WebView.m_SetVisible = env->GetMethodID(webview_class, "setVisible", "(II)V");
     g_WebView.m_IsVisible = env->GetMethodID(webview_class, "isVisible", "(I)I");
     g_WebView.m_SetPosition = env->GetMethodID(webview_class, "setPosition", "(IIIII)V");
+    g_WebView.m_AddHeader = env->GetMethodID(webview_class, "addHeader", "(ILjava/lang/String;Ljava/lang/String;)V");
 
     int32_t immersiveMode = dmConfigFile::GetInt(params->m_ConfigFile, "android.immersive_mode", 0);
     int32_t displayCutout = dmConfigFile::GetInt(params->m_ConfigFile, "android.display_cutout", 1);

--- a/webview/src/webview_common.cpp
+++ b/webview/src/webview_common.cpp
@@ -131,6 +131,7 @@ static int Destroy(lua_State* L)
 
 void ParseHeaders(lua_State* L, int argumentindex, int webview_id)
 {
+    Platform_ClearHeaders(L, webview_id);
     luaL_checktype(L, argumentindex, LUA_TTABLE);
     lua_pushvalue(L, argumentindex);
     lua_pushnil(L);
@@ -166,11 +167,6 @@ void ParseOptions(lua_State* L, int argumentindex, int webview_id, RequestInfo* 
     lua_pop(L, 1);
 }
 
-
-/** Opens an url in the view
-@param url url
-@return the request id
-*/
 static int Open(lua_State* L)
 {
     int top = lua_gettop(L);

--- a/webview/src/webview_common.cpp
+++ b/webview/src/webview_common.cpp
@@ -134,12 +134,30 @@ void ParseHeaders(lua_State* L, int argumentindex, int webview_id)
     Platform_ClearHeaders(L, webview_id);
     luaL_checktype(L, argumentindex, LUA_TTABLE);
     lua_pushvalue(L, argumentindex);
+
+    // first key
     lua_pushnil(L);
+
+    // push key-value pair
     while (lua_next(L, -2))
     {
-        const char* header = lua_tostring(L, -2);
+        // push copy of key (ie the header), convert it, pop it
+        // note from Lua docs: If the value is a number, then lua_tolstring also
+        // changes the actual value in the stack to a string. This change
+        // confuses lua_next when lua_tolstring is applied to keys during a
+        // table traversal
+        lua_pushvalue(L, -2);
+        const char* header = lua_tostring(L, -1);
+        lua_pop(L, 1);
+
+        // push copy of value, convert it, pop it
+        lua_pushvalue(L, -1);
         const char* value = lua_tostring(L, -1);
+        lua_pop(L, 1);
+
         Platform_AddHeader(L, webview_id, header, value);
+
+        // remove value, keep key for lua_next
         lua_pop(L, 1);
     }
     lua_pop(L, 1);
@@ -152,7 +170,9 @@ void ParseOptions(lua_State* L, int argumentindex, int webview_id, RequestInfo* 
     lua_pushvalue(L, argumentindex);
     lua_pushnil(L);
     while (lua_next(L, -2)) {
-        const char* attr = lua_tostring(L, -2);
+        lua_pushvalue(L, -2);
+        const char* attr = lua_tostring(L, -1);
+        lua_pop(L, 1);
         if( strcmp(attr, "hidden") == 0 )
         {
             luaL_checktype(L, -1, LUA_TBOOLEAN);

--- a/webview/src/webview_common.h
+++ b/webview/src/webview_common.h
@@ -67,6 +67,7 @@ int Platform_Eval(lua_State* L, int webview_id, const char* code);
 int Platform_SetVisible(lua_State* L, int webview_id, int visible);
 int Platform_IsVisible(lua_State* L, int webview_id);
 int Platform_SetPosition(lua_State* L, int webview_id, int x, int y, int width, int height);
+int Platform_AddHeader(lua_State* L, int webview_id, const char* header, const char* value);
 
 // The extension life cycle functions
 dmExtension::Result Platform_AppInitialize(dmExtension::AppParams* params);

--- a/webview/src/webview_common.h
+++ b/webview/src/webview_common.h
@@ -68,6 +68,7 @@ int Platform_SetVisible(lua_State* L, int webview_id, int visible);
 int Platform_IsVisible(lua_State* L, int webview_id);
 int Platform_SetPosition(lua_State* L, int webview_id, int x, int y, int width, int height);
 int Platform_AddHeader(lua_State* L, int webview_id, const char* header, const char* value);
+int Platform_ClearHeaders(lua_State* L, int webview_id);
 
 // The extension life cycle functions
 dmExtension::Result Platform_AppInitialize(dmExtension::AppParams* params);

--- a/webview/src/webview_darwin.mm
+++ b/webview/src/webview_darwin.mm
@@ -248,6 +248,13 @@ static void DestroyWebView(int webview_id)
     g_WebView.m_WebViews[webview_id] = NULL;
 }
 
+int Platform_ClearHeaders(lua_State* L, int webview_id)
+{
+    CHECK_WEBVIEW_AND_RETURN();
+    [g_WebView.m_WebViewDelegates[webview_id]->m_Headers removeAllObjects];
+    return 0;
+}
+
 int Platform_AddHeader(lua_State* L, int webview_id, const char* header, const char* value)
 {
     CHECK_WEBVIEW_AND_RETURN();

--- a/webview/src/webview_darwin.mm
+++ b/webview/src/webview_darwin.mm
@@ -44,6 +44,8 @@ struct Command
     @public int m_WebViewID;
     @public int m_RequestID;
     @public NSString *m_PendingUrl;
+    @public bool m_HeadersSet;
+    @public NSMutableDictionary* m_Headers;
     @public void (^m_DecisionHandler)(WKNavigationActionPolicy);
 }
 @end
@@ -84,23 +86,50 @@ WebViewExtensionState g_WebView;
     // if this happens it means that we have navigated to a new page
     // before the previous callback completed
     // if we don't make a decision we'll get an error
-    if (m_DecisionHandler) {
+    if (m_DecisionHandler)
+    {
         m_DecisionHandler(WKNavigationActionPolicyCancel);
         m_DecisionHandler = NULL;
     }
 
-    NSString *url = navigationAction.request.URL.absoluteString;
-    m_PendingUrl = url;
-    m_DecisionHandler = decisionHandler;
+    // if headers have not been set we first copy the request
+    // and then set the headers on the request and finally
+    // we cancel the original request and load the new one
+    if (!m_HeadersSet)
+    {
+        // cancel original request
+        decisionHandler(WKNavigationActionPolicyCancel);
 
-    dmWebView::CallbackInfo cbinfo;
-    cbinfo.m_Info = &g_WebView.m_Info[m_WebViewID];
-    cbinfo.m_WebViewID = m_WebViewID;
-    cbinfo.m_RequestID = m_RequestID;
-    cbinfo.m_Url = [url UTF8String];
-    cbinfo.m_Type = dmWebView::CALLBACK_RESULT_URL_LOADING;
-    cbinfo.m_Result = 0;
-    RunCallback(&cbinfo);
+        // copy request and add headers
+        NSMutableURLRequest *newRequest = [[NSMutableURLRequest alloc] initWithURL:navigationAction.request.URL];
+        for (NSString *header in m_Headers)
+        {
+            NSString *value = m_Headers[header];
+            [newRequest setValue:value forHTTPHeaderField:header];
+        }
+        m_HeadersSet = true;
+
+        // load the new request
+        WKWebView* webview = g_WebView.m_WebViews[m_WebViewID];
+        [webview loadRequest:newRequest];
+    }
+    else
+    {
+        // headers have been set and we proceed to ask the user if
+        // the navigation should be allowed or not
+        NSString *url = navigationAction.request.URL.absoluteString;
+        m_PendingUrl = url;
+        m_DecisionHandler = decisionHandler;
+
+        dmWebView::CallbackInfo cbinfo;
+        cbinfo.m_Info = &g_WebView.m_Info[m_WebViewID];
+        cbinfo.m_WebViewID = m_WebViewID;
+        cbinfo.m_RequestID = m_RequestID;
+        cbinfo.m_Url = [url UTF8String];
+        cbinfo.m_Type = dmWebView::CALLBACK_RESULT_URL_LOADING;
+        cbinfo.m_Result = 0;
+        RunCallback(&cbinfo);
+    }
 }
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
@@ -186,6 +215,7 @@ int Platform_Create(lua_State* L, dmWebView::WebViewInfo* _info)
     navigationDelegate->m_RequestID = 0;
     navigationDelegate->m_PendingUrl = NULL;
     navigationDelegate->m_DecisionHandler = NULL;
+    navigationDelegate->m_Headers = [[NSMutableDictionary alloc] init];
     view.navigationDelegate = navigationDelegate;
 
     g_WebView.m_WebViews[webview_id] = view;
@@ -216,6 +246,15 @@ static void DestroyWebView(int webview_id)
     [view removeFromSuperview];
     [view release];
     g_WebView.m_WebViews[webview_id] = NULL;
+}
+
+int Platform_AddHeader(lua_State* L, int webview_id, const char* header, const char* value)
+{
+    CHECK_WEBVIEW_AND_RETURN();
+    NSString* ns_header = [NSString stringWithUTF8String: header];
+    NSString* ns_value = [NSString stringWithUTF8String: value];
+    g_WebView.m_WebViewDelegates[webview_id]->m_Headers[ns_header] = ns_value;
+    return 0;
 }
 
 int Platform_Destroy(lua_State* L, int webview_id)
@@ -253,6 +292,7 @@ int Platform_ContinueOpen(lua_State* L, int webview_id, int request_id, const ch
     if ([delegate->m_PendingUrl isEqualToString:[NSString stringWithUTF8String: url]]) {
         delegate->m_DecisionHandler(WKNavigationActionPolicyAllow);
         delegate->m_DecisionHandler = NULL;
+        delegate->m_HeadersSet = false;
     }
     return request_id;
 }
@@ -264,6 +304,7 @@ int Platform_CancelOpen(lua_State* L, int webview_id, int request_id, const char
     if ([delegate->m_PendingUrl isEqualToString:[NSString stringWithUTF8String: url]]) {
         delegate->m_DecisionHandler(WKNavigationActionPolicyCancel);
         delegate->m_DecisionHandler = NULL;
+        delegate->m_HeadersSet = false;
     }
     return request_id;
 }


### PR DESCRIPTION
Added option to set custom headers on any navigation request in the loaded content in the webview:

```lua
local options = {
    headers = {
        ["Accept-Origin"] = "*",
        ["User-Agent"] = "Foobar 1.0",
    }
}
webview.open(self.webview_id, "https://www.google.com", options)
```

Fixes #34 