### PR TITLE
Added support for transparency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ Thumbs.db
 .cproject
 builtins
 docs/_site
+.editor_settings
+debug.keystore
+debug.keystore.pass.txt
+manifest.private.der
+manifest.public.der

--- a/main/main.atlas
+++ b/main/main.atlas
@@ -1,0 +1,4 @@
+images {
+  image: "/builtins/assets/images/logo/logo_256.png"
+}
+extrude_borders: 2

--- a/main/main.gui
+++ b/main/main.gui
@@ -1,1137 +1,381 @@
 script: "/main/main.gui_script"
-background_color {
-  x: 0.0
-  y: 0.0
-  z: 0.0
-  w: 0.0
+textures {
+  name: "main"
+  texture: "/main/main.atlas"
 }
 nodes {
   position {
     x: 320.0
-    y: 195.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
+    y: 273.0
   }
   scale {
     x: 0.5
     y: 0.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEMPLATE
   id: "button_open"
-  layer: ""
   inherit_alpha: true
-  alpha: 1.0
   template: "/dirtylarry/button.gui"
-  template_node_child: false
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
   size {
     x: 800.0
     y: 120.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: "button/button_normal"
   id: "button_open/larrybutton"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
   parent: "button_open"
-  layer: ""
-  inherit_alpha: true
-  slice9 {
-    x: 32.0
-    y: 32.0
-    z: 32.0
-    w: 32.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
   overridden_fields: 4
   template_node_child: true
-  size_mode: SIZE_MODE_MANUAL
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
   scale {
     x: 1.5
     y: 1.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
   text: "Open www.google.com"
-  font: "larryfont"
   id: "button_open/larrylabel"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  outline {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
   parent: "button_open/larrybutton"
-  layer: ""
-  inherit_alpha: true
-  alpha: 1.0
   outline_alpha: 0.0
-  shadow_alpha: 1.0
   overridden_fields: 3
   overridden_fields: 8
   overridden_fields: 31
   template_node_child: true
-  text_leading: 1.0
-  text_tracking: 0.0
 }
 nodes {
   position {
     x: 215.0
-    y: 125.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
+    y: 203.0
   }
   scale {
     x: 0.5
     y: 0.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEMPLATE
   id: "button_show"
-  layer: ""
   inherit_alpha: true
-  alpha: 1.0
   template: "/dirtylarry/button.gui"
-  template_node_child: false
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
   size {
     x: 380.0
     y: 120.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: "button/button_normal"
   id: "button_show/larrybutton"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
   parent: "button_show"
-  layer: ""
-  inherit_alpha: true
-  slice9 {
-    x: 32.0
-    y: 32.0
-    z: 32.0
-    w: 32.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
   overridden_fields: 4
   template_node_child: true
-  size_mode: SIZE_MODE_MANUAL
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
   scale {
     x: 1.5
     y: 1.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
   text: "Show"
-  font: "larryfont"
   id: "button_show/larrylabel"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  outline {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
   parent: "button_show/larrybutton"
-  layer: ""
-  inherit_alpha: true
-  alpha: 1.0
   outline_alpha: 0.0
-  shadow_alpha: 1.0
   overridden_fields: 3
   overridden_fields: 8
   overridden_fields: 31
   template_node_child: true
-  text_leading: 1.0
-  text_tracking: 0.0
 }
 nodes {
   position {
     x: 425.0
-    y: 125.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
+    y: 203.0
   }
   scale {
     x: 0.5
     y: 0.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEMPLATE
   id: "button_hide"
-  layer: ""
   inherit_alpha: true
-  alpha: 1.0
   template: "/dirtylarry/button.gui"
-  template_node_child: false
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
   size {
     x: 380.0
     y: 120.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: "button/button_normal"
   id: "button_hide/larrybutton"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
   parent: "button_hide"
-  layer: ""
-  inherit_alpha: true
-  slice9 {
-    x: 32.0
-    y: 32.0
-    z: 32.0
-    w: 32.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
   overridden_fields: 4
   template_node_child: true
-  size_mode: SIZE_MODE_MANUAL
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
   scale {
     x: 1.5
     y: 1.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
   text: "Hide"
-  font: "larryfont"
   id: "button_hide/larrylabel"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  outline {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
   parent: "button_hide/larrybutton"
-  layer: ""
-  inherit_alpha: true
-  alpha: 1.0
   outline_alpha: 0.0
-  shadow_alpha: 1.0
   overridden_fields: 3
   overridden_fields: 8
   overridden_fields: 31
   template_node_child: true
-  text_leading: 1.0
-  text_tracking: 0.0
 }
 nodes {
   position {
     x: 320.0
-    y: 335.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
+    y: 413.0
   }
   scale {
     x: 0.5
     y: 0.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEMPLATE
   id: "button_eval"
-  layer: ""
   inherit_alpha: true
-  alpha: 1.0
   template: "/dirtylarry/button.gui"
-  template_node_child: false
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
   size {
     x: 800.0
     y: 120.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: "button/button_normal"
   id: "button_eval/larrybutton"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
   parent: "button_eval"
-  layer: ""
-  inherit_alpha: true
-  slice9 {
-    x: 32.0
-    y: 32.0
-    z: 32.0
-    w: 32.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
   overridden_fields: 4
   template_node_child: true
-  size_mode: SIZE_MODE_MANUAL
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
   scale {
     x: 1.5
     y: 1.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
   text: "Eval 1+1"
-  font: "larryfont"
   id: "button_eval/larrylabel"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  outline {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
   parent: "button_eval/larrybutton"
-  layer: ""
-  inherit_alpha: true
-  alpha: 1.0
   outline_alpha: 0.0
-  shadow_alpha: 1.0
   overridden_fields: 3
   overridden_fields: 8
   overridden_fields: 31
   template_node_child: true
-  text_leading: 1.0
-  text_tracking: 0.0
 }
 nodes {
   position {
     x: 320.0
-    y: 265.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
+    y: 343.0
   }
   scale {
     x: 0.5
     y: 0.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEMPLATE
   id: "button_html"
-  layer: ""
   inherit_alpha: true
-  alpha: 1.0
   template: "/dirtylarry/button.gui"
-  template_node_child: false
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
   size {
     x: 800.0
     y: 120.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: "button/button_normal"
   id: "button_html/larrybutton"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
   parent: "button_html"
-  layer: ""
-  inherit_alpha: true
-  slice9 {
-    x: 32.0
-    y: 32.0
-    z: 32.0
-    w: 32.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
   overridden_fields: 4
   template_node_child: true
-  size_mode: SIZE_MODE_MANUAL
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
   scale {
     x: 1.5
     y: 1.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
   text: "Open HTML"
-  font: "larryfont"
   id: "button_html/larrylabel"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  outline {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
   parent: "button_html/larrybutton"
-  layer: ""
-  inherit_alpha: true
-  alpha: 1.0
   outline_alpha: 0.0
-  shadow_alpha: 1.0
   overridden_fields: 3
   overridden_fields: 8
   overridden_fields: 31
   template_node_child: true
-  text_leading: 1.0
-  text_tracking: 0.0
+}
+nodes {
+  position {
+    x: 215.0
+    y: 133.0
+  }
+  scale {
+    x: 0.5
+    y: 0.5
+  }
+  type: TYPE_TEMPLATE
+  id: "button_create"
+  inherit_alpha: true
+  template: "/dirtylarry/button.gui"
+}
+nodes {
+  size {
+    x: 380.0
+    y: 120.0
+  }
+  type: TYPE_BOX
+  id: "button_create/larrybutton"
+  parent: "button_create"
+  overridden_fields: 4
+  template_node_child: true
+}
+nodes {
+  scale {
+    x: 1.5
+    y: 1.5
+  }
+  type: TYPE_TEXT
+  text: "Create"
+  id: "button_create/larrylabel"
+  parent: "button_create/larrybutton"
+  outline_alpha: 0.0
+  overridden_fields: 3
+  overridden_fields: 8
+  overridden_fields: 31
+  template_node_child: true
+}
+nodes {
+  position {
+    x: 425.0
+    y: 133.0
+  }
+  scale {
+    x: 0.5
+    y: 0.5
+  }
+  type: TYPE_TEMPLATE
+  id: "button_destroy"
+  inherit_alpha: true
+  template: "/dirtylarry/button.gui"
+}
+nodes {
+  size {
+    x: 380.0
+    y: 120.0
+  }
+  type: TYPE_BOX
+  id: "button_destroy/larrybutton"
+  parent: "button_destroy"
+  overridden_fields: 4
+  template_node_child: true
+}
+nodes {
+  scale {
+    x: 1.5
+    y: 1.5
+  }
+  type: TYPE_TEXT
+  text: "Destroy"
+  id: "button_destroy/larrylabel"
+  parent: "button_destroy/larrybutton"
+  outline_alpha: 0.0
+  overridden_fields: 3
+  overridden_fields: 8
+  overridden_fields: 31
+  template_node_child: true
 }
 nodes {
   position {
     x: 215.0
     y: 55.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
   }
   scale {
     x: 0.5
     y: 0.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEMPLATE
-  id: "button_create"
-  layer: ""
+  id: "button_opaque"
   inherit_alpha: true
-  alpha: 1.0
   template: "/dirtylarry/button.gui"
-  template_node_child: false
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
   size {
     x: 380.0
     y: 120.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: "button/button_normal"
-  id: "button_create/larrybutton"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
-  parent: "button_create"
-  layer: ""
-  inherit_alpha: true
-  slice9 {
-    x: 32.0
-    y: 32.0
-    z: 32.0
-    w: 32.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
+  id: "button_opaque/larrybutton"
+  parent: "button_opaque"
   overridden_fields: 4
   template_node_child: true
-  size_mode: SIZE_MODE_MANUAL
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
   scale {
     x: 1.5
     y: 1.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
-  text: "Create"
-  font: "larryfont"
-  id: "button_create/larrylabel"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  outline {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
-  parent: "button_create/larrybutton"
-  layer: ""
-  inherit_alpha: true
-  alpha: 1.0
+  text: "Opaque"
+  id: "button_opaque/larrylabel"
+  parent: "button_opaque/larrybutton"
   outline_alpha: 0.0
-  shadow_alpha: 1.0
   overridden_fields: 3
   overridden_fields: 8
   overridden_fields: 31
   template_node_child: true
-  text_leading: 1.0
-  text_tracking: 0.0
 }
 nodes {
   position {
     x: 425.0
     y: 55.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
   }
   scale {
     x: 0.5
     y: 0.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEMPLATE
-  id: "button_destroy"
-  layer: ""
+  id: "button_transparent"
   inherit_alpha: true
-  alpha: 1.0
   template: "/dirtylarry/button.gui"
-  template_node_child: false
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
   size {
     x: 380.0
     y: 120.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_BOX
-  blend_mode: BLEND_MODE_ALPHA
-  texture: "button/button_normal"
-  id: "button_destroy/larrybutton"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  adjust_mode: ADJUST_MODE_FIT
-  parent: "button_destroy"
-  layer: ""
-  inherit_alpha: true
-  slice9 {
-    x: 32.0
-    y: 32.0
-    z: 32.0
-    w: 32.0
-  }
-  clipping_mode: CLIPPING_MODE_NONE
-  clipping_visible: true
-  clipping_inverted: false
-  alpha: 1.0
+  id: "button_transparent/larrybutton"
+  parent: "button_transparent"
   overridden_fields: 4
   template_node_child: true
-  size_mode: SIZE_MODE_MANUAL
 }
 nodes {
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
   scale {
     x: 1.5
     y: 1.5
-    z: 1.0
-    w: 1.0
-  }
-  size {
-    x: 200.0
-    y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
-  text: "Destroy"
-  font: "larryfont"
-  id: "button_destroy/larrylabel"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
-  pivot: PIVOT_CENTER
-  outline {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  shadow {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
-  }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
-  parent: "button_destroy/larrybutton"
-  layer: ""
-  inherit_alpha: true
-  alpha: 1.0
+  text: "Transparent"
+  id: "button_transparent/larrylabel"
+  parent: "button_transparent/larrybutton"
   outline_alpha: 0.0
-  shadow_alpha: 1.0
   overridden_fields: 3
   overridden_fields: 8
   overridden_fields: 31
   template_node_child: true
-  text_leading: 1.0
-  text_tracking: 0.0
+}
+nodes {
+  position {
+    y: 960.0
+  }
+  type: TYPE_BOX
+  texture: "main/logo_256"
+  id: "logo"
+  xanchor: XANCHOR_LEFT
+  yanchor: YANCHOR_TOP
+  pivot: PIVOT_NW
+  adjust_mode: ADJUST_MODE_ZOOM
+  inherit_alpha: true
+  size_mode: SIZE_MODE_AUTO
 }
 material: "/builtins/materials/gui.material"
 adjust_reference: ADJUST_REFERENCE_PARENT
-max_nodes: 512

--- a/main/main.gui_script
+++ b/main/main.gui_script
@@ -5,7 +5,7 @@ HTML = [[
 <head>
     <title>Defold webview</title>
 </head>
-<body>
+<body style="background-color:transparent;">
 Hello World
 </body>
 </html>
@@ -76,7 +76,7 @@ function init(self)
     if not webview_available() then return end
 
     self.webview_id = webview.create(webview_callback)
-    webview.set_position(self.webview_id, 0, 0, -1, 300)
+    webview.set_position(self.webview_id, 0, 0, -1, 1000)
 
     self.width = gui.get_width()
     self.height = gui.get_height()
@@ -130,5 +130,15 @@ function on_input(self, action_id, action)
 
         webview.destroy(self.webview_id)
         self.webview_id = nil
+    end)
+
+    dirtylarry:button("button_opaque", action_id, action, function()
+        if not webview_exists(self) then return end
+        webview.set_transparent(self.webview_id, false)
+    end)
+
+    dirtylarry:button("button_transparent", action_id, action, function()
+        if not webview_exists(self) then return end
+        webview.set_transparent(self.webview_id, true)
     end)
 end

--- a/webview/api/webview.script_api
+++ b/webview/api/webview.script_api
@@ -111,6 +111,9 @@
           - name: hidden
             type: boolean
             desc: If true, the webview will stay hidden (default=false)
+          - name: transparent
+            type: boolean
+            desc: If true, the webview background will be transparent (default=false)
     examples:
       - desc: |-
                  ```lua
@@ -157,6 +160,17 @@
                  ```lua
                  local request_id = webview.eval(webview_id, "GetMyFormData()")
                  ```
+
+  - name: set_transparent
+    type: function
+    desc: Set transparency of webview background
+    parameters:
+      - name: webview_id
+        type: number
+        desc: The webview id
+      - name: transparent
+        type: boolean
+        desc: If `true`, the webview background becomes transparent, otherwise opaque.
 
   - name: set_visible
     type: function

--- a/webview/src/java/com/defold/webview/WebViewJNI.java
+++ b/webview/src/java/com/defold/webview/WebViewJNI.java
@@ -25,6 +25,9 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.webkit.WebSettings;
 
+import android.graphics.PixelFormat;
+import android.graphics.Color;
+
 import android.util.Log;
 
 
@@ -252,6 +255,7 @@ public class WebViewJNI {
         info.windowParams.height = WindowManager.LayoutParams.MATCH_PARENT;
         info.windowParams.flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE; // Fix navigation bar visible briefly when hiding/showing
         info.windowParams.softInputMode = WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING;
+        info.windowParams.format = PixelFormat.TRANSLUCENT; // To be able to make webview transparent
         if (Build.VERSION.SDK_INT < 30) {
             if (immersiveMode) {
                 info.windowParams.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE
@@ -275,6 +279,11 @@ public class WebViewJNI {
 
         info.layout.setLayoutParams(info.windowParams);
         return info;
+    }
+
+    private void setTransparentInternal(WebViewInfo info, final int transparent)
+    {
+        info.webview.setBackgroundColor((transparent == 1) ? Color.TRANSPARENT : Color.WHITE);
     }
 
     private void setVisibleInternal(WebViewInfo info, int visible)
@@ -344,7 +353,7 @@ public class WebViewJNI {
         });
     }
 
-    public void loadRaw(final String html, final int webview_id, final int request_id, final int hidden) {
+    public void loadRaw(final String html, final int webview_id, final int request_id, final int hidden, final int transparent) {
         this.activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -353,11 +362,12 @@ public class WebViewJNI {
                 WebViewJNI.this.infos[webview_id].webviewClient.setContinueLoadingUrl("file:///android_res/");
                 WebViewJNI.this.infos[webview_id].webview.loadDataWithBaseURL("file:///android_res/", html, "text/html", "utf-8", null);
                 setVisibleInternal(WebViewJNI.this.infos[webview_id], hidden != 0 ? 0 : 1);
+                setTransparentInternal(WebViewJNI.this.infos[webview_id], transparent);
             }
         });
     }
 
-    public void load(final String url, final int webview_id, final int request_id, final int hidden) {
+    public void load(final String url, final int webview_id, final int request_id, final int hidden, final int transparent) {
         this.activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -366,6 +376,7 @@ public class WebViewJNI {
                 WebViewJNI.this.infos[webview_id].webviewClient.setContinueLoadingUrl(url);
                 WebViewJNI.this.infos[webview_id].webview.loadUrl(url);
                 setVisibleInternal(WebViewJNI.this.infos[webview_id], hidden != 0 ? 0 : 1);
+                setTransparentInternal(WebViewJNI.this.infos[webview_id], transparent);
             }
         });
     }
@@ -413,6 +424,15 @@ public class WebViewJNI {
             @Override
             public void run() {
                 setPositionInternal(WebViewJNI.this.infos[webview_id], x, y, width, height);
+            }
+        });
+    }
+
+    public void setTransparent(final int webview_id, final int transparent) {
+        this.activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                setTransparentInternal(WebViewJNI.this.infos[webview_id], transparent);
             }
         });
     }

--- a/webview/src/webview_android.cpp
+++ b/webview/src/webview_android.cpp
@@ -64,6 +64,7 @@ struct WebViewExtensionState
     jmethodID               m_LoadRaw;
     jmethodID               m_ContinueLoading;
     jmethodID               m_Eval;
+    jmethodID               m_SetTransparent;
     jmethodID               m_SetVisible;
     jmethodID               m_IsVisible;
     jmethodID               m_SetPosition;
@@ -132,7 +133,7 @@ int Platform_Open(lua_State* L, int webview_id, const char* url, dmWebView::Requ
     dmAndroid::ThreadAttacher threadAttacher;
     JNIEnv* env = threadAttacher.GetEnv();
     jstring jurl = env->NewStringUTF(url);
-    env->CallVoidMethod(g_WebView.m_WebViewJNI, g_WebView.m_Load, jurl, webview_id, request_id, options->m_Hidden);
+    env->CallVoidMethod(g_WebView.m_WebViewJNI, g_WebView.m_Load, jurl, webview_id, request_id, options->m_Hidden, options->m_Transparent);
     env->DeleteLocalRef(jurl);
     return request_id;
 }
@@ -163,7 +164,7 @@ int Platform_OpenRaw(lua_State* L, int webview_id, const char* html, dmWebView::
     dmAndroid::ThreadAttacher threadAttacher;
     JNIEnv* env = threadAttacher.GetEnv();
     jstring jhtml = env->NewStringUTF(html);
-    env->CallVoidMethod(g_WebView.m_WebViewJNI, g_WebView.m_LoadRaw, jhtml, webview_id, request_id, options->m_Hidden);
+    env->CallVoidMethod(g_WebView.m_WebViewJNI, g_WebView.m_LoadRaw, jhtml, webview_id, request_id, options->m_Hidden, options->m_Transparent);
     env->DeleteLocalRef(jhtml);
     return request_id;
 }
@@ -178,6 +179,15 @@ int Platform_Eval(lua_State* L, int webview_id, const char* code)
     jstring jcode = env->NewStringUTF(code);
     env->CallVoidMethod(g_WebView.m_WebViewJNI, g_WebView.m_Eval, jcode, webview_id, request_id);
     return request_id;
+}
+
+int Platform_SetTransparent(lua_State* L, int webview_id, int transparent)
+{
+    CHECK_WEBVIEW_AND_RETURN();
+    dmAndroid::ThreadAttacher threadAttacher;
+    JNIEnv* env = threadAttacher.GetEnv();
+    env->CallVoidMethod(g_WebView.m_WebViewJNI, g_WebView.m_SetTransparent, webview_id, transparent);
+    return 0;
 }
 
 int Platform_SetVisible(lua_State* L, int webview_id, int visible)
@@ -383,11 +393,12 @@ dmExtension::Result Platform_AppInitialize(dmExtension::AppParams* params)
 
     g_WebView.m_Create = env->GetMethodID(webview_class, "create", "(I)V");
     g_WebView.m_Destroy = env->GetMethodID(webview_class, "destroy", "(I)V");
-    g_WebView.m_Load = env->GetMethodID(webview_class, "load", "(Ljava/lang/String;III)V");
-    g_WebView.m_LoadRaw = env->GetMethodID(webview_class, "loadRaw", "(Ljava/lang/String;III)V");
+    g_WebView.m_Load = env->GetMethodID(webview_class, "load", "(Ljava/lang/String;IIII)V");
+    g_WebView.m_LoadRaw = env->GetMethodID(webview_class, "loadRaw", "(Ljava/lang/String;IIII)V");
     g_WebView.m_ContinueLoading = env->GetMethodID(webview_class, "continueLoading", "(Ljava/lang/String;II)V");
     g_WebView.m_Eval = env->GetMethodID(webview_class, "eval", "(Ljava/lang/String;II)V");
     g_WebView.m_SetVisible = env->GetMethodID(webview_class, "setVisible", "(II)V");
+    g_WebView.m_SetTransparent = env->GetMethodID(webview_class, "setTransparent", "(II)V");
     g_WebView.m_IsVisible = env->GetMethodID(webview_class, "isVisible", "(I)I");
     g_WebView.m_SetPosition = env->GetMethodID(webview_class, "setPosition", "(IIIII)V");
 

--- a/webview/src/webview_common.cpp
+++ b/webview/src/webview_common.cpp
@@ -95,6 +95,14 @@ static int Create(lua_State* L)
 {
     int top = lua_gettop(L);
 
+    int index = 1;
+    if (lua_type(L, 1) == LUA_TTABLE)
+    {
+        index = index +1;
+    }
+    luaL_checktype(L, 1, LUA_TFUNCTION);
+
+
     luaL_checktype(L, 1, LUA_TFUNCTION);
     lua_pushvalue(L, 1);
 
@@ -139,6 +147,11 @@ void ParseOptions(lua_State* L, int argumentindex, RequestInfo* requestinfo)
         {
             luaL_checktype(L, -1, LUA_TBOOLEAN);
             requestinfo->m_Hidden = lua_toboolean(L, -1);
+        }
+        else if( strcmp(attr, "transparent") == 0 )
+        {
+            luaL_checktype(L, -1, LUA_TBOOLEAN);
+            requestinfo->m_Transparent = lua_toboolean(L, -1);
         }
         lua_pop(L, 1);
     }
@@ -204,9 +217,29 @@ static int SetVisible(lua_State* L)
 {
     int top = lua_gettop(L);
     const int webview_id = luaL_checknumber(L, 1);
-    const int visible = luaL_checknumber(L, 2);
+    int visible = 0;
+    if (lua_type(L, 2) == LUA_TNUMBER)
+    {
+        visible = luaL_checknumber(L, 2);
+    }
+    else
+    {
+        visible = lua_toboolean(L, 2);
+    }
 
     Platform_SetVisible(L, webview_id, visible);
+
+    assert(top == lua_gettop(L));
+    return 0;
+}
+
+static int SetTransparent(lua_State* L)
+{
+    int top = lua_gettop(L);
+    const int webview_id = luaL_checknumber(L, 1);
+    const int transparent = lua_toboolean(L, 2);
+
+    Platform_SetTransparent(L, webview_id, transparent);
 
     assert(top == lua_gettop(L));
     return 0;
@@ -247,6 +280,7 @@ static const luaL_reg WebView_methods[] =
     {"open_raw", OpenRaw},
     {"eval", Eval},
     {"set_visible", SetVisible},
+    {"set_transparent", SetTransparent},
     {"set_position", SetPosition},
     {"is_visible", IsVisible},
     {0, 0}

--- a/webview/src/webview_common.h
+++ b/webview/src/webview_common.h
@@ -30,6 +30,7 @@ struct WebViewInfo
 struct RequestInfo
 {
     int         m_Hidden;
+    int         m_Transparent;
 
     RequestInfo() : m_Hidden(0) {}
 };
@@ -64,6 +65,7 @@ int Platform_OpenRaw(lua_State* L, int webview_id, const char* html, dmWebView::
 int Platform_ContinueOpen(lua_State* L, int webview_id, int request_id, const char* url);
 int Platform_CancelOpen(lua_State* L, int webview_id, int request_id, const char* url);
 int Platform_Eval(lua_State* L, int webview_id, const char* code);
+int Platform_SetTransparent(lua_State* L, int webview_id, int transparent);
 int Platform_SetVisible(lua_State* L, int webview_id, int visible);
 int Platform_IsVisible(lua_State* L, int webview_id);
 int Platform_SetPosition(lua_State* L, int webview_id, int x, int y, int width, int height);


### PR DESCRIPTION
It is now possible to make the webview background transparent:

```lua
local id = webview.create(...)

-- two different ways to set the background color to transparent
webview.open(id, url, { transparent = true })
webview.set_transparent(id, true)
```

Fixes #32