### PR TITLE
Add Android R8 keep rules

### DIFF
--- a/webview/manifests/android/webview.keep
+++ b/webview/manifests/android/webview.keep
@@ -1,0 +1,5 @@
+# Native code loads the WebView bridge and invokes its methods by name.
+-keep,allowoptimization class com.defold.webview.** { *; }
+
+# Preserve the runtime annotation used by the JavaScript interface bridge.
+-keepattributes *Annotation*


### PR DESCRIPTION
Native Android code loads this extension's Java bridge and invokes its methods by name through JNI. Add `webview/manifests/android/webview.keep` to preserve those classes and members during R8 shrinking and obfuscation.

Preserves runtime annotations used by the JavaScript interface.

Applies the changes from `37b78e8b942299f4004b7969b56c3af3de6dddf8` on the latest `master`.

Validation: checked the Java bridge and native JNI references; verified that the branch contains one commit with the same patch as the supplied commit; `git diff --check` passes. Android builds and device tests were not run for this PR preparation.
